### PR TITLE
Revert "Fix beyond styles"

### DIFF
--- a/addons/stripper/maps/surf_beyond.cfg
+++ b/addons/stripper/maps/surf_beyond.cfg
@@ -2,38 +2,10 @@ modify:
 {
 	match:
 	{
-		"classname" "trigger_teleport"
+	"classname" "trigger_teleport"
 	}
 	insert:
 	{
-		"UseLandmarkAngles" "0"
-	}
-	delete:
-	{
-        	"OnStartTouch" "!activatorRunScriptCodeself.SetVelocity(Vector(0, 0, 0))0-1"
-	}
-}
-modify:
-{
-	match:
-	{
-		"classname" "trigger_multiple"
-	}
-	delete:
-	{
-		"OnStartTouch" "!activatorAddOutputgravity 10-1"
-		"spawnflags" "1"
-	}
-}
-modify:
-{
-	match:
-	{
-		"classname" "trigger_multiple"
-		"hammerid" "893347"
-	}
-	insert:
-	{
-		"OnStartTouch" "!activatorAddOutputgravity 000"
+	"UseLandmarkAngles" "0"
 	}
 }


### PR DESCRIPTION
Reverts surftimer/Surftimer-olokos#191

@sneak-it 
``
the vscript that was deleted sets the player's velocity to 0 0 0 so that drops are fixed between stages
has nothing to do with gravity and is a map feature, which many maps should objectively have
idk if beyond has player clip boxes to stop people from telehopping or not but now you have to snipe teleporters to ensure you get the best time in a map run
that one change completely alters existing map times

the gravity thing is a temp fix i suppose but that in the end should be adapted to the timer so we don't have to stripper 'fix' every single map that has a gravity change
but the velocity thing is just dead wrong
``